### PR TITLE
More user friendly error messages, sent to STDERR instead of STDOUT

### DIFF
--- a/changelog_generator.php
+++ b/changelog_generator.php
@@ -58,8 +58,8 @@ do {
 } while (!$done && !$error && ($i < 5));
 
 if ($error) {
-    var_export($error);
-    exit(0);
+    fwrite(STDERR,sprintf("Github API returned error message [%s]\n",$error->message));
+    exit(1);
 }
 
 echo "Total issues resolved: **" . count($issues) . "**\n";


### PR DESCRIPTION
Upon firing up the code I was confused by the default error messages. This simply clarifies what the user is seeing is an error message from the github API, and shows them the message itself instead of the raw JSON object. It also sends this error to STDERR for better command line & piping form
