### PR TITLE
Lower local project autoload priority

### DIFF
--- a/changelog_generator.php
+++ b/changelog_generator.php
@@ -16,18 +16,18 @@ $autoloadLocations = array(
     __DIR__ . '/../../autoload.php',
     getcwd() . '/vendor/autoload.php',
 );
-$autoloaderLoaded  = false;
 
 foreach ($autoloadLocations as $location) {
     if (!file_exists($location)) {
         continue;
     }
-    require $location;
-    $autoloaderLoaded  = true;
+
+    $autoloader = require $location;
+
     break;
 }
 
-if (!$autoloaderLoaded) {
+if (! (isset($autoloader) && $autoloader)) {
     file_put_contents('php://stderr', "Failed to discover autoloader; please install dependencies and/or install via Composer.\n");
     exit(1);
 }


### PR DESCRIPTION
Lowers priority of local autoloader path.
This is particularly useful while working with the tool installed as a globally available executable
