### PR TITLE
Add quotes to milestone in case title contains spaces

### DIFF
--- a/changelog_generator.php
+++ b/changelog_generator.php
@@ -82,7 +82,7 @@ if (! isset($milestonePayload['title'])) {
 
 $client->setUri(
     'https://api.github.com/search/issues?q=' . urlencode(
-        'milestone:' . $milestonePayload['title']
+        'milestone:"' . $milestonePayload['title'] . '"'
         .' repo:' . $user . '/' . $repo
         . ' state:closed'
     )

--- a/changelog_generator.php
+++ b/changelog_generator.php
@@ -82,7 +82,7 @@ if (! isset($milestonePayload['title'])) {
 
 $client->setUri(
     'https://api.github.com/search/issues?q=' . urlencode(
-        'milestone:"' . $milestonePayload['title'] . '"'
+        'milestone:"' . str_replace('"', '\"', $milestonePayload['title']) . '"'
         .' repo:' . $user . '/' . $repo
         . ' state:closed'
     )


### PR DESCRIPTION
Discovered a bug where if the milestone title contains a space (e.g. `1.0.0 (initial release)`), the search fails to find any issues. Simple fix here is to always quote the `milestone`, I see no adverse affects with milestones that do not contain spaces (e.g. `1.0.0`).