### PR TITLE
Add a blank line before the bullets

### DIFF
--- a/changelog_generator.php
+++ b/changelog_generator.php
@@ -126,7 +126,7 @@ do {
     break; // yay for tail recursion emulation =_=
 } while (true);
 
-echo "Total issues resolved: **" . count($issues) . "**" . PHP_EOL;
+echo "Total issues resolved: **" . count($issues) . "**" . PHP_EOL . PHP_EOL;
 
 $textualIssues = [];
 


### PR DESCRIPTION
Markdown.pl doesn't convert a list to `<ul>` unless there is a blank
line before the list.